### PR TITLE
Support ignore tag prefix

### DIFF
--- a/_example/example.go
+++ b/_example/example.go
@@ -13,6 +13,7 @@ type User struct {
 	Name      string
 	CreatedAt time.Time
 	UpdatedAt time.Time
+	Token     string `ddl:"-"`
 }
 
 func (u *User) Table() string {

--- a/ddlmaker.go
+++ b/ddlmaker.go
@@ -15,8 +15,8 @@ import (
 const (
 	// TAGPREFIX is struct tag field prefix
 	TAGPREFIX = "ddl"
-	// IGNORETAGPREFIX using ignore struct field
-	IGNORETAGPREFIX = "-"
+	// IGNORETAG using ignore struct field
+	IGNORETAG = "-"
 )
 
 var (

--- a/ddlmaker.go
+++ b/ddlmaker.go
@@ -15,6 +15,13 @@ import (
 const (
 	// TAGPREFIX is struct tag field prefix
 	TAGPREFIX = "ddl"
+	// IGNORETAGPREFIX using ignore struct field
+	IGNORETAGPREFIX = "-"
+)
+
+var (
+	// ErrIgnoreField is Ignore Field Error
+	ErrIgnoreField = errors.New("error ignore this field")
 )
 
 // DDLMaker XXX

--- a/parser.go
+++ b/parser.go
@@ -52,7 +52,7 @@ func parseField(field reflect.StructField, d dialect.Dialect) (dialect.Column, e
 	tagStr := strings.Replace(field.Tag.Get(TAGPREFIX), " ", "", -1)
 
 	for _, tag := range strings.Split(tagStr, ",") {
-		if tag == IGNORETAGPREFIX {
+		if tag == IGNORETAG {
 			return nil, ErrIgnoreField
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package ddlmaker
 
 import (
 	"fmt"
+	"log"
 	"reflect"
 	"strings"
 
@@ -32,7 +33,13 @@ func (dm *DDLMaker) parse() {
 		var columns []dialect.Column
 		for i := 0; i < rt.NumField(); i++ {
 			rtField := rt.Field(i)
-			column := parseField(rtField, dm.Dialect)
+			column, err := parseField(rtField, dm.Dialect)
+			if err != nil {
+				if err == ErrIgnoreField {
+					continue
+				}
+				log.Fatalln("error parse field", err.Error())
+			}
 			columns = append(columns, column)
 		}
 
@@ -41,8 +48,14 @@ func (dm *DDLMaker) parse() {
 	}
 }
 
-func parseField(field reflect.StructField, d dialect.Dialect) dialect.Column {
+func parseField(field reflect.StructField, d dialect.Dialect) (dialect.Column, error) {
 	tagStr := strings.Replace(field.Tag.Get(TAGPREFIX), " ", "", -1)
+
+	for _, tag := range strings.Split(tagStr, ",") {
+		if tag == IGNORETAGPREFIX {
+			return nil, ErrIgnoreField
+		}
+	}
 
 	var typeName string
 	if field.Type.PkgPath() != "" {
@@ -60,7 +73,7 @@ func parseField(field reflect.StructField, d dialect.Dialect) dialect.Column {
 		typeName = field.Type.Name()
 	}
 
-	return newColumn(snaker.CamelToSnake(field.Name), typeName, tagStr, d)
+	return newColumn(snaker.CamelToSnake(field.Name), typeName, tagStr, d), nil
 }
 
 func parseTable(s interface{}, columns []dialect.Column, d dialect.Dialect) dialect.Table {

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,6 +15,7 @@ type T1 struct {
 	Name        string
 	Description sql.NullString `ddl:"null,text"`
 	CreatedAt   time.Time
+	Ignore      string `ddl:"-"`
 }
 
 func (t1 T1) Table() string {
@@ -64,7 +65,13 @@ func TestParseField(t *testing.T) {
 	}
 
 	for i := 0; i < rt.NumField(); i++ {
-		column := parseField(rt.Field(i), mysql.MySQL{})
+		column, err := parseField(rt.Field(i), mysql.MySQL{})
+		if err != nil {
+			if err == ErrIgnoreField {
+				continue
+			}
+			t.Fatal("error parse field", err.Error())
+		}
 
 		if !reflect.DeepEqual(columns[i], column) {
 			t.Fatalf("parsed %s: %v is different \n %s: %v", column.Name(), column, columns[i].Name(), columns[i])


### PR DESCRIPTION
In order not to change the interface and design greatly, we will return an error if there is a tag to ignore in parsing