### PR TITLE
nullable time.Time support

### DIFF
--- a/dialect/mysql/mysql.go
+++ b/dialect/mysql/mysql.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	defaultVarcharSize = 191
-	autoIncrement     = "AUTO_INCREMENT"
+	autoIncrement      = "AUTO_INCREMENT"
 )
 
 // MySQL XXX
@@ -93,6 +93,8 @@ func (mysql MySQL) ToSQL(typeName string, size uint64) string {
 	case "time":
 		return "TIME"
 	case "time.Time":
+		return "DATETIME"
+	case "mysql.NullTime": // https://godoc.org/github.com/go-sql-driver/mysql#NullTime
 		return "DATETIME"
 	default:
 		log.Fatalf("%s is not match.", typeName)

--- a/dialect/mysql/mysql_test.go
+++ b/dialect/mysql/mysql_test.go
@@ -50,6 +50,11 @@ func TestToSQL(t *testing.T) {
 	if m.ToSQL("time", 0) != "TIME" {
 		t.Fatalf("error %s to sql %s. but result %s", "time", "TIME", m.ToSQL("type", 0))
 	}
+
+	// https://godoc.org/github.com/go-sql-driver/mysql#NullTime
+	if m.ToSQL("mysql.NullTime", 0) != "DATETIME" {
+		t.Fatalf("error %s to sql %s. but result %s", "mysql.NullTime", "DATETIME", m.ToSQL("mysql.NullTime", 0))
+	}
 }
 
 func TestQuote(t *testing.T) {


### PR DESCRIPTION
The github.com/go-sql-driver/mysql supports nullable `time.Time`.
https://github.com/go-sql-driver/mysql#timetime-support