### PR TITLE
fix wrong error report of the test for the `time` type.

### DIFF
--- a/dialect/mysql/mysql_test.go
+++ b/dialect/mysql/mysql_test.go
@@ -48,7 +48,7 @@ func TestToSQL(t *testing.T) {
 	}
 
 	if m.ToSQL("time", 0) != "TIME" {
-		t.Fatalf("error %s to sql %s. but result %s", "time", "TIME", m.ToSQL("type", 0))
+		t.Fatalf("error %s to sql %s. but result %s", "time", "TIME", m.ToSQL("time", 0))
 	}
 }
 


### PR DESCRIPTION
It should be `m.ToSQL("time", 0)`, not `m.ToSQL("type", 0)`.