### PR TITLE
support JSON type

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ ___
 |  string, sql.NullString   |      VARCHAR      |
 |    bool, sql.NullBool     |    TINYINT(1)     |
 | time.Time, mysql.NullTime |     DATETIME      |
+|      json.RawMessage      |        JSON       |
 
 [mysql.NullTime](https://godoc.org/github.com/go-sql-driver/mysql#NullTime) is from [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql).
 

--- a/dialect/mysql/mysql.go
+++ b/dialect/mysql/mysql.go
@@ -113,6 +113,8 @@ func (mysql MySQL) ToSQL(typeName string, size uint64) string {
 		return "DATETIME"
 	case "mysql.NullTime": // https://godoc.org/github.com/go-sql-driver/mysql#NullTime
 		return "DATETIME"
+	case "json.RawMessage", "*json.RawMessage":
+		return "JSON"
 	default:
 		log.Fatalf("%s is not match.", typeName)
 	}

--- a/dialect/mysql/mysql_test.go
+++ b/dialect/mysql/mysql_test.go
@@ -57,6 +57,7 @@ func TestToSQL(t *testing.T) {
 		{"time", 0, "TIME"},
 		{"time.Time", 0, "DATETIME"},
 		{"mysql.NullTime", 0, "DATETIME"}, // https://godoc.org/github.com/go-sql-driver/mysql#NullTime
+		{"json.RawMessage", 0, "JSON"},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
I want to use MySQL's [JSON Data Type](https://dev.mysql.com/doc/refman/5.7/en/json.html).
It's corresponding type for Golang should be [json.RawMessage](https://golang.org/pkg/encoding/json/#RawMessage).

``` go
package main

import (
	"database/sql"
	"encoding/json"
	"log"

	_ "github.com/go-sql-driver/mysql"
)

func main() {
	// docker run -d -p 127.0.0.1:3306:3306 --name mysqld -e MYSQL_DATABASE=gotest -e MYSQL_USER=gotest -e MYSQL_PASSWORD=secret -e MYSQL_ROOT_PASSWORD=verysecret mysql:5.7 --innodb_log_file_size=256MB --innodb_buffer_pool_size=512MB --max_allowed_packet=16MB
	db, err := sql.Open("mysql", "gotest:secret@tcp(localhost:3306)/gotest")
	if err != nil {
		panic(err)
	}

	_, err = db.Exec("DROP TABLE IF EXISTS `gopher`")
	if err != nil {
		panic(err)
	}

	_, err = db.Exec("CREATE TABLE `gopher` ( `id` INT NOT NULL AUTO_INCREMENT, `meta` JSON NOT NULL, PRIMARY KEY (`id`) )")
	if err != nil {
		panic(err)
	}

	msg := json.RawMessage(`{"hogehoge": ["a", "b", "c"], "fooo":"fooo"}`)
	ret, err := db.Exec("INSERT INTO `gopher` (`meta`) VALUES (?)", msg)
	if err != nil {
		panic(err)
	}

	id, err := ret.LastInsertId()
	if err != nil {
		panic(err)
	}

	row := db.QueryRow("SELECT `meta` FROM `gopher` WHERE `id` = ?", id)
	if err != nil {
		panic(err)
	}

	var got json.RawMessage
	if err := row.Scan(&got); err != nil {
		panic(err)
	}

	log.Println(string(got))

	db.Close()
}
```