### PR TITLE
Add new nullable types

### DIFF
--- a/dialect/mysql/mysql.go
+++ b/dialect/mysql/mysql.go
@@ -69,7 +69,7 @@ func (mysql MySQL) ToSQL(typeName string, size uint64) string {
 		return "TINYINT"
 	case "int16", "*int16":
 		return "SMALLINT"
-	case "int32", "*int32":
+	case "int32", "*int32", "sql.NullInt32": // from Go 1.13
 		return "INTEGER"
 	case "int64", "*int64", "sql.NullInt64":
 		return "BIGINT"
@@ -112,6 +112,8 @@ func (mysql MySQL) ToSQL(typeName string, size uint64) string {
 	case "time.Time", "*time.Time":
 		return "DATETIME"
 	case "mysql.NullTime": // https://godoc.org/github.com/go-sql-driver/mysql#NullTime
+		return "DATETIME"
+	case "sql.NullTime": // from Go 1.13
 		return "DATETIME"
 	case "json.RawMessage", "*json.RawMessage":
 		return "JSON"

--- a/dialect/mysql/mysql_test.go
+++ b/dialect/mysql/mysql_test.go
@@ -22,6 +22,7 @@ func TestToSQL(t *testing.T) {
 		{"*int16", 0, "SMALLINT"},
 		{"int32", 0, "INTEGER"},
 		{"*int32", 0, "INTEGER"},
+		{"sql.NullInt32", 0, "INTEGER"},
 		{"int64", 0, "BIGINT"},
 		{"*int64", 0, "BIGINT"},
 		{"sql.NullInt64", 0, "BIGINT"},
@@ -57,6 +58,7 @@ func TestToSQL(t *testing.T) {
 		{"time", 0, "TIME"},
 		{"time.Time", 0, "DATETIME"},
 		{"mysql.NullTime", 0, "DATETIME"}, // https://godoc.org/github.com/go-sql-driver/mysql#NullTime
+		{"sql.NullTime", 0, "DATETIME"},   // from Go 1.13
 		{"json.RawMessage", 0, "JSON"},
 	}
 


### PR DESCRIPTION
new nullable types are available from Go 1.13.

https://golang.org/doc/go1.13#database/sql

> The new NullTime type represents a time.Time that may be null.
> The new NullInt32 type represents an int32 that may be null.
