### PR TITLE
datetime type accepts size

### DIFF
--- a/dialect/mysql/mysql.go
+++ b/dialect/mysql/mysql.go
@@ -118,11 +118,11 @@ func (mysql MySQL) ToSQL(typeName string, size uint64) string {
 	case "time":
 		return "TIME"
 	case "time.Time", "*time.Time":
-		return "DATETIME"
+		return datetime(size)
 	case "mysql.NullTime": // https://godoc.org/github.com/go-sql-driver/mysql#NullTime
-		return "DATETIME"
+		return datetime(size)
 	case "sql.NullTime": // from Go 1.13
-		return "DATETIME"
+		return datetime(size)
 	case "date":
 		return "DATE"
 	case "json.RawMessage", "*json.RawMessage":
@@ -278,6 +278,14 @@ func varbinary(size uint64) string {
 	}
 
 	return fmt.Sprintf("VARBINARY(%d)", size)
+}
+
+func datetime(size uint64) string {
+	if size == 0 {
+		return "DATETIME"
+	}
+
+	return fmt.Sprintf("DATETIME(%d)", size)
 }
 
 func quote(s string) string {

--- a/dialect/mysql/mysql_test.go
+++ b/dialect/mysql/mysql_test.go
@@ -57,6 +57,7 @@ func TestToSQL(t *testing.T) {
 		{"longblob", 0, "LONGBLOB"},
 		{"time", 0, "TIME"},
 		{"time.Time", 0, "DATETIME"},
+		{"time.Time", 6, "DATETIME(6)"},
 		{"mysql.NullTime", 0, "DATETIME"}, // https://godoc.org/github.com/go-sql-driver/mysql#NullTime
 		{"sql.NullTime", 0, "DATETIME"},   // from Go 1.13
 		{"date", 0, "DATE"},


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/fractional-seconds.html

MySQL can include a fractional seconds part.
e.g. `dt DATETIME(6)` has microseconds (6 digits) precision.