### PR TITLE
Remove test on 1.12

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,15 +6,13 @@ on:
     branches: [master]
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.16', '1.15', '1.14', '1.13', '1.12']
+        go: ["1.16", "1.15", "1.14", "1.13"]
     steps:
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Each major Go release is supported until there are two newer major releases.